### PR TITLE
updated active project CTA & project management policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Want to start an Open Austin project?
 
 Looking to jump into an existing project?
 
-#### [:floppy_disk: View Repositories for our Active Projects :floppy_disk:](http://www.github.com/open-austin)
+#### [:floppy_disk: Dive right into an Active Project :floppy_disk:](http://www.github.com/open-austin)
 
 
 ## About the Open Austin Hack Team
@@ -35,17 +35,19 @@ Thanks for co-creating with us!
 
 #### Comment on an existing idea (a.k.a. "issue")
 
-Scroll through the [issues list](https://github.com/open-austin/project-ideas/issues) first to see if anyone's already thinking the same way! If you see an idea that catches your eye, click on it, read the discussion, and then add your thoughts to the bottom of the discussion thread. 
+Scroll through the [issues list](https://github.com/open-austin/project-ideas/issues) first to see if anyone's already thinking the same way! If you see an idea that catches your eye, click on it, read the discussion, and then add your thoughts to the bottom of the discussion thread. If you see the **Needs Leadership** label, bring it up at a hack night, and if you're up for it you can take the lead on it!
 
 #### Or, create a new idea.
 
-If you don't see the idea you have in mind, [add a new one](https://github.com/code4sac/projects/issues/new). You'll need a title and description. Someone from the Open Austin Core Team will respond, likely with some questions or feedback. 
+If you don't see the idea you have in mind, [add a new one](https://github.com/code4sac/projects/issues/new). You'll need a title and description. Someone from the Open Austin Core Team will respond, likely with some questions or feedback, and assign you to the issue to indicate you are leading the effort.
 
 *Here's a [quick video intro](https://www.youtube.com/watch?v=KlrJVSJRUN4) on using Github Issues for discussion.*
 
 ### Next Steps
 
+* Please make a status update to your issues at least once a month to keep others informed. If we don't hear from you after some time, we might assume you've moved on and will ask others to take the lead.
+
 * If nobody's talking yet, it might be that your idea needs some more fleshing out. We highly recommend thinking through the [Civic Tech Canvas](https://github.com/open-austin/civic-tech-canvas) as a next step! 
 
-* If you're willing to be the champion on this project, you should let one of our [project leads](mailto:hack@open-austin.org) know. GitHub is the platform we're using to collect ideas, vet ideas, and convert those ideas into active projects. Once a project becomes active, we'll help you **set up repository** on the Open Austin GitHub page so you can start scoping and collaborating. We'll continue to use the Issues feature to flag obstacles, opportunities, and answer questions about that specific project.
+* If you're willing to be the champion on this project, you should let one of our [project leads](mailto:hack@open-austin.org) know. GitHub is the platform we're using to collect and vet ideas and then convert them into [active projects](https://github.com/open-austin). Once a project becomes active, we'll help you set up a repository on the Open Austin GitHub organization so you can start scoping and collaborating. We'll continue to use the Issues feature on your own project repo to flag obstacles, opportunities, and answer questions about that specific project. We will then add the project repo link to your idea issue and close it, indicating your graduation from idea to an active project.
 


### PR DESCRIPTION
Active project CTA at the top was a bit lackluster, so I used a little more engaging phrasing. Also added PM policy to keep the idea to project pipeline moving. See discussion at https://open-austin.slack.com/archives/C40QKGF17/p1491157434217886