### PR TITLE
change code of conduct link

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -49,7 +49,7 @@ Let's get this project started! When this idea starts taking off, the Projects C
 #### Checklist for FEATURED Projects :tada:
 To have your project FEATURED on [Open-Austin.org](https://open-austin.org/), complete the following documentation. In past projects, well-documented featured projects have more contributions than other projects.
 
-* [ ] In your README, link to the [Open Austin Community Participation Guidelines](https://docs.google.com/document/d/1OujyBccPpepUXSY5_nP3alzvd81WlCKSeSf_-sU5K-U/edit?usp=sharing) or write your own code of conduct.
+* [ ] In your README, link to the [Open Austin Code of Conduct](https://www.open-austin.org/about/#code-of-conduct) or write your own code of conduct.
 * [ ] [Create file: LICENSE](http://choosealicense.com/) to give your project an open license, allowing for sharing and remixing.
 * [ ] [Create file: CONTRIBUTING.md](https://github.com/acabunoc/mozsprint-repo-template/blob/master/CONTRIBUTING.md) so others know [how they can contribute](https://mozilla.github.io/open-leadership-training-series/articles/building-communities-of-contributors/write-contributor-guidelines/).
 * [ ] Create an easily shareable project management artifact, like a [Civic Tech Canvas](https://cityofaustin.github.io/civic-tech-canvas/) or [Open Canvas](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/)


### PR DESCRIPTION
Changes the Checklist for Featured Products to say the alternative to making your own code of conduct is linking to the Open Austin code of conduct, instead of linking to the Open Austin Values document. The values statement isn't really a substitute for a code of conduct, and the values document has some random unorganized notes at the bottom that most people don't need to read.